### PR TITLE
Share PMS5003 readings across interfaces

### DIFF
--- a/Rpi5/WebInterface.py
+++ b/Rpi5/WebInterface.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 import time
 import threading
+import json
+from pathlib import Path
 from flask import Flask, render_template_string, jsonify
 from smbus2 import SMBus
 
@@ -25,6 +27,7 @@ from SensorBox import (
 )
 
 app = Flask(__name__)
+DATA_FILE = Path(__file__).resolve().parent / "latest.json"
 
 # ------------------------ Sensor initialisation -------------------------
 bus = SMBus(I2C_BUS)
@@ -99,6 +102,19 @@ def _poll_sensors() -> None:
                 data["PM1"] = f"{s['pm1']} µg/m³"
                 data["PM2.5"] = f"{s['pm25']} µg/m³"
                 data["PM10"] = f"{s['pm10']} µg/m³"
+            except Exception:
+                pass
+        else:
+            # Fallback: read particulate data written by SensorBox.py
+            try:
+                with DATA_FILE.open(encoding="utf-8") as fh:
+                    d = json.load(fh)
+                if "PM1" in d:
+                    data["PM1"] = f"{d['PM1']} µg/m³"
+                if "PM2.5" in d:
+                    data["PM2.5"] = f"{d['PM2.5']} µg/m³"
+                if "PM10" in d:
+                    data["PM10"] = f"{d['PM10']} µg/m³"
             except Exception:
                 pass
 


### PR DESCRIPTION
## Summary
- Persist latest sensor measurements to `latest.json`
- Read particulate data from shared file in Tkinter interface
- Fall back to shared PMS5003 data in web UI when serial port is busy

## Testing
- `python -m py_compile Rpi5/SensorBox.py Rpi5/WebInterface.py Rpi5/Interface.py`


------
https://chatgpt.com/codex/tasks/task_e_68b91ee7760083269ee3a35159793c12