### PR TITLE
docs: add Raspberry Pi 5 setup instructions

### DIFF
--- a/Rpi5/README.md
+++ b/Rpi5/README.md
@@ -1,15 +1,62 @@
 # SensorBox-Python
 
-## Requirements :
-to make communication between Raspberry Pi 5 and some sensors (sgp30, aht20, bmp280), you first need to slightly edit your ```/boot/firmware/config.txt``` file by adding ```dtoverlay=i2c0``` at the end and then reboot.
+## Raspberry Pi 5 pre-configuration
 
-```
-sudo nano /boot/firmware/config.txt
-sudo reboot
-```
+Follow these steps to prepare a Raspberry Pi 5 before running the SensorBox scripts and connecting the sensors.
 
-To see if it worked, you will have to enter the following command and check if your Raspberry Pi recognizes any device connected through SDA and SCL :
+1. **Update the system**
 
-```
-i2cdetect -y -r 0
-```
+   ```bash
+   sudo apt update
+   sudo apt full-upgrade -y
+   ```
+
+2. **Install required packages**
+
+   ```bash
+   sudo apt install -y python3-pip python3-smbus i2c-tools git
+   pip3 install smbus2 gpiozero pyserial flask
+   ```
+
+3. **Enable interfaces**
+
+   Launch `raspi-config` and activate the hardware interfaces used by the sensors:
+
+   ```bash
+   sudo raspi-config
+   ```
+
+   - *Interface Options → I2C* → **Enable**
+   - *Interface Options → Serial Port* → **Disable** the login shell and **Enable** the serial hardware
+
+4. **Edit the boot configuration**
+
+   Add the overlays required for I²C bus 0 and for the UART port:
+
+   ```bash
+   sudo nano /boot/firmware/config.txt
+   ```
+
+   Append the following lines at the end of the file then save:
+
+   ```
+   dtoverlay=i2c0
+   enable_uart=1
+   ```
+
+   Reboot to apply the changes:
+
+   ```bash
+   sudo reboot
+   ```
+
+5. **Verify I²C bus 0**
+
+   After reboot, ensure that the connected sensors appear on bus 0:
+
+   ```bash
+   i2cdetect -y -r 0
+   ```
+
+   You should see addresses listed for any devices connected via SDA/SCL.
+


### PR DESCRIPTION
## Summary
- document system updates, package installations, interface enabling, boot config overlays, and verification steps for Raspberry Pi 5

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb54cac1ec83269320d395f8de7b38