### PR TITLE
Separate HTML template from WebInterface

### DIFF
--- a/Rpi5/WebInterface.py
+++ b/Rpi5/WebInterface.py
@@ -13,7 +13,7 @@ import time
 import threading
 import json
 from pathlib import Path
-from flask import Flask, render_template_string, jsonify
+from flask import Flask, render_template, jsonify
 from smbus2 import SMBus
 
 from SensorBox import (
@@ -133,117 +133,11 @@ def get_latest() -> dict[str, str]:
         return dict(latest)
 
 
-TEMPLATE = """
-<!doctype html>
-<html lang="fr">
-<head>
-  <meta charset="utf-8">
-  <title>SensorBox</title>
-  <meta http-equiv="refresh" content="5">
-  <style>
-    body {
-      background: linear-gradient(135deg, #2c3e50, #3498db);
-      color: #ecf0f1;
-      font-family: "Segoe UI", Arial, sans-serif;
-      text-align: center;
-      margin: 0;
-      padding: 0;
-    }
-    h1 {
-      margin-top: 30px;
-      font-size: 2.5em;
-      color: #f1c40f;
-      text-shadow: 2px 2px 5px rgba(0,0,0,0.3);
-    }
-    .box {
-      background: rgba(255, 255, 255, 0.05);
-      border-radius: 15px;
-      padding: 20px;
-      margin: 30px auto;
-      width: 70%;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.3);
-    }
-    ul { list-style: none; padding: 0; margin: 0; }
-    li {
-      background: rgba(255, 255, 255, 0.1);
-      border-radius: 10px;
-      margin: 12px auto;
-      padding: 12px 18px;
-      font-size: 1.2em;
-      box-shadow: 0 3px 6px rgba(0,0,0,0.2);
-      transition: transform 0.2s;
-      width: 100%;
-    }
-    li:hover { transform: scale(1.03); background: rgba(255, 255, 255, 0.2); }
-    .sensor-name { color: white; }
-    .danger { color: #e74c3c; font-weight: bold; }
-  </style>
-</head>
-<body>
-  <h1>SensorBox</h1>
-
-  <!-- Boîte 1 : mesures environnementales -->
-  <div class="box">
-    <ul>
-      {% for key, val in data.items() %}
-        {% set k = key|lower %}
-        {% set is_air_quality = (
-             'co2' in k
-          or 'tvoc' in k
-          or 'voc' in k
-          or 'aqi' in k
-          or 'pm' in k
-          or 'hcho' in k
-          or 'no2' in k
-          or 'o3'  in k
-          or 'so2' in k
-          or (k == 'co')
-        ) %}
-        {% if not is_air_quality %}
-          <li>
-            <span class="sensor-name">{{ key }}:</span>
-            <span class="{% if 'DANGER' in val %}danger{% endif %}">{{ val }}</span>
-          </li>
-        {% endif %}
-      {% endfor %}
-    </ul>
-  </div>
-
-  <!-- Boîte 2 : mesures qualité de l'air -->
-  <div class="box">
-    <ul>
-      {% for key, val in data.items() %}
-        {% set k = key|lower %}
-        {% if
-             'co2' in k
-          or 'tvoc' in k
-          or 'voc' in k
-          or 'aqi' in k
-          or 'pm' in k
-          or 'hcho' in k
-          or 'no2' in k
-          or 'o3'  in k
-          or 'so2' in k
-          or (k == 'co')
-        %}
-          <li>
-            <span class="sensor-name">{{ key }}:</span>
-            <span class="{% if 'DANGER' in val %}danger{% endif %}">{{ val }}</span>
-          </li>
-        {% endif %}
-      {% endfor %}
-    </ul>
-  </div>
-</body>
-</html>
-"""
-
-
 
 
 @app.route("/")
 def index():
-    return render_template_string(TEMPLATE, data=get_latest())
+    return render_template("index.html", data=get_latest())
 
 
 @app.route("/data")

--- a/Rpi5/templates/index.html
+++ b/Rpi5/templates/index.html
@@ -1,0 +1,102 @@
+<!doctype html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <title>SensorBox</title>
+  <meta http-equiv="refresh" content="5">
+  <style>
+    body {
+      background: linear-gradient(135deg, #2c3e50, #3498db);
+      color: #ecf0f1;
+      font-family: "Segoe UI", Arial, sans-serif;
+      text-align: center;
+      margin: 0;
+      padding: 0;
+    }
+    h1 {
+      margin-top: 30px;
+      font-size: 2.5em;
+      color: #f1c40f;
+      text-shadow: 2px 2px 5px rgba(0,0,0,0.3);
+    }
+    .box {
+      background: rgba(255, 255, 255, 0.05);
+      border-radius: 15px;
+      padding: 20px;
+      margin: 30px auto;
+      width: 70%;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+    }
+    ul { list-style: none; padding: 0; margin: 0; }
+    li {
+      background: rgba(255, 255, 255, 0.1);
+      border-radius: 10px;
+      margin: 12px auto;
+      padding: 12px 18px;
+      font-size: 1.2em;
+      box-shadow: 0 3px 6px rgba(0,0,0,0.2);
+      transition: transform 0.2s;
+      width: 100%;
+    }
+    li:hover { transform: scale(1.03); background: rgba(255, 255, 255, 0.2); }
+    .sensor-name { color: white; }
+    .danger { color: #e74c3c; font-weight: bold; }
+  </style>
+</head>
+<body>
+  <h1>SensorBox</h1>
+
+  <!-- Boîte 1 : mesures environnementales -->
+  <div class="box">
+    <ul>
+      {% for key, val in data.items() %}
+        {% set k = key|lower %}
+        {% set is_air_quality = (
+             'co2' in k
+          or 'tvoc' in k
+          or 'voc' in k
+          or 'aqi' in k
+          or 'pm' in k
+          or 'hcho' in k
+          or 'no2' in k
+          or 'o3'  in k
+          or 'so2' in k
+          or (k == 'co')
+        ) %}
+        {% if not is_air_quality %}
+          <li>
+            <span class="sensor-name">{{ key }}:</span>
+            <span class="{% if 'DANGER' in val %}danger{% endif %}">{{ val }}</span>
+          </li>
+        {% endif %}
+      {% endfor %}
+    </ul>
+  </div>
+
+  <!-- Boîte 2 : mesures qualité de l'air -->
+  <div class="box">
+    <ul>
+      {% for key, val in data.items() %}
+        {% set k = key|lower %}
+        {% if
+             'co2' in k
+          or 'tvoc' in k
+          or 'voc' in k
+          or 'aqi' in k
+          or 'pm' in k
+          or 'hcho' in k
+          or 'no2' in k
+          or 'o3'  in k
+          or 'so2' in k
+          or (k == 'co')
+        %}
+          <li>
+            <span class="sensor-name">{{ key }}:</span>
+            <span class="{% if 'DANGER' in val %}danger{% endif %}">{{ val }}</span>
+          </li>
+        {% endif %}
+      {% endfor %}
+    </ul>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- move HTML template into `templates/index.html`
- load template using `render_template` instead of an inline string

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbb48610388326bdd3e3cedff028ba