### PR TITLE
feat: refine web interface styling

### DIFF
--- a/Rpi5/templates/index.html
+++ b/Rpi5/templates/index.html
@@ -6,40 +6,39 @@
   <meta http-equiv="refresh" content="5">
   <style>
     body {
-      background: linear-gradient(135deg, #2c3e50, #3498db);
-      color: #ecf0f1;
+      background: #f4f6f7;
+      color: #2c3e50;
       font-family: "Segoe UI", Arial, sans-serif;
       text-align: center;
       margin: 0;
-      padding: 0;
     }
     h1 {
       margin-top: 30px;
       font-size: 2.5em;
-      color: #f1c40f;
-      text-shadow: 2px 2px 5px rgba(0,0,0,0.3);
+      color: #34495e;
     }
     .box {
-      background: rgba(255, 255, 255, 0.05);
-      border-radius: 15px;
+      background: #ffffff;
+      border-radius: 8px;
       padding: 20px;
       margin: 30px auto;
-      width: 70%;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+      max-width: 800px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
     }
     ul { list-style: none; padding: 0; margin: 0; }
     li {
-      background: rgba(255, 255, 255, 0.1);
-      border-radius: 10px;
+      background: #fafafa;
+      border-radius: 6px;
       margin: 12px auto;
       padding: 12px 18px;
-      font-size: 1.2em;
-      box-shadow: 0 3px 6px rgba(0,0,0,0.2);
+      font-size: 1.1em;
+      box-shadow: 0 1px 4px rgba(0,0,0,0.1);
       transition: transform 0.2s;
-      width: 100%;
+      width: 80%;
+      box-sizing: border-box;
     }
-    li:hover { transform: scale(1.03); background: rgba(255, 255, 255, 0.2); }
-    .sensor-name { color: white; }
+    li:hover { transform: translateY(-2px); background: #f0f0f0; }
+    .sensor-name { color: #2c3e50; font-weight: 600; }
     .danger { color: #e74c3c; font-weight: bold; }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- modernize web page with cleaner colors and subtle card styling
- center data items within their boxes and prevent overflow

## Testing
- `python -m pytest`
- `python -m py_compile Rpi5/WebInterface.py`


------
https://chatgpt.com/codex/tasks/task_e_68bbb652c7ec83269dd6e7f7c5ec40b3