### PR TITLE
Highlight hazardous sensor readings on web interface

### DIFF
--- a/Rpi5/templates/index.html
+++ b/Rpi5/templates/index.html
@@ -65,7 +65,7 @@
         {% if not is_air_quality %}
           <li>
             <span class="sensor-name">{{ key }}:</span>
-            <span class="{% if 'DANGER' in val %}danger{% endif %}">{{ val }}</span>
+            <span class="{% if key in danger %}danger{% endif %}">{{ val }}</span>
           </li>
         {% endif %}
       {% endfor %}
@@ -91,7 +91,7 @@
         %}
           <li>
             <span class="sensor-name">{{ key }}:</span>
-            <span class="{% if 'DANGER' in val %}danger{% endif %}">{{ val }}</span>
+            <span class="{% if key in danger %}danger{% endif %}">{{ val }}</span>
           </li>
         {% endif %}
       {% endfor %}


### PR DESCRIPTION
## Summary
- track keys exceeding thresholds and store them separately
- template marks those keys with a `danger` class so no warning text appears

## Testing
- `python -m py_compile Rpi5/WebInterface.py`


------
https://chatgpt.com/codex/tasks/task_e_68bbba8eba608326a2ff700db4cf436a