### PR TITLE
Remove danger label from high values

### DIFF
--- a/Rpi5/templates/index.html
+++ b/Rpi5/templates/index.html
@@ -65,7 +65,7 @@
         {% if not is_air_quality %}
           <li>
             <span class="sensor-name">{{ key }}:</span>
-            <span class="{% if 'DANGER' in val %}danger{% endif %}">{{ val }}</span>
+            <span class="{% if 'DANGER' in val %}danger{% endif %}">{{ val | replace(' DANGER', '') | trim }}</span>
           </li>
         {% endif %}
       {% endfor %}
@@ -91,7 +91,7 @@
         %}
           <li>
             <span class="sensor-name">{{ key }}:</span>
-            <span class="{% if 'DANGER' in val %}danger{% endif %}">{{ val }}</span>
+            <span class="{% if 'DANGER' in val %}danger{% endif %}">{{ val | replace(' DANGER', '') | trim }}</span>
           </li>
         {% endif %}
       {% endfor %}


### PR DESCRIPTION
## Summary
- Hide `DANGER` text in web UI while keeping red highlighting

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbbe1664b8832692676afe04d17ecc