### PR TITLE
Hide readings for disconnected sensors

### DIFF
--- a/Rpi5/WebInterface.py
+++ b/Rpi5/WebInterface.py
@@ -11,9 +11,7 @@ from __future__ import annotations
 
 import time
 import threading
-import json
 import re
-from pathlib import Path
 from flask import Flask, render_template, jsonify
 from smbus2 import SMBus
 
@@ -28,7 +26,6 @@ from SensorBox import (
 )
 
 app = Flask(__name__)
-DATA_FILE = Path(__file__).resolve().parent / "latest.json"
 
 # ------------------------ Sensor initialisation -------------------------
 bus = SMBus(I2C_BUS)
@@ -52,16 +49,7 @@ except Exception:  # sensor not present
     pms = None
 
 
-latest: dict[str, str] = {
-    "eCO2": "—",
-    "TVOC": "—",
-    "Temperature": "—",
-    "Relative Humidity": "—",
-    "Pressure": "—",
-    "PM1": "—",
-    "PM2.5": "—",
-    "PM10": "—",
-}
+latest: dict[str, str] = {}
 _lock = threading.Lock()
 
 THRESHOLDS = {
@@ -123,23 +111,11 @@ def _poll_sensors() -> None:
                 data["PM10"] = f"{s['pm10']} µg/m³"
             except Exception:
                 pass
-        else:
-            # Fallback: read particulate data written by SensorBox.py
-            try:
-                with DATA_FILE.open(encoding="utf-8") as fh:
-                    d = json.load(fh)
-                if "PM1" in d:
-                    data["PM1"] = f"{d['PM1']} µg/m³"
-                if "PM2.5" in d:
-                    data["PM2.5"] = f"{d['PM2.5']} µg/m³"
-                if "PM10" in d:
-                    data["PM10"] = f"{d['PM10']} µg/m³"
-            except Exception:
-                pass
 
         _apply_thresholds(data)
 
         with _lock:
+            latest.clear()
             latest.update(data)
 
         time.sleep(1.0)

--- a/Rpi5/templates/index.html
+++ b/Rpi5/templates/index.html
@@ -45,57 +45,54 @@
 <body>
   <h1>SensorBox</h1>
 
+  {% set ns = namespace(env=[], air=[]) %}
+  {% for key, val in data.items() %}
+    {% set k = key|lower %}
+    {% set is_air_quality = (
+         'co2' in k
+      or 'tvoc' in k
+      or 'voc' in k
+      or 'aqi' in k
+      or 'pm' in k
+      or 'hcho' in k
+      or 'no2' in k
+      or 'o3'  in k
+      or 'so2' in k
+      or (k == 'co')
+    ) %}
+    {% if is_air_quality %}
+      {% set ns.air = ns.air + [(key, val)] %}
+    {% else %}
+      {% set ns.env = ns.env + [(key, val)] %}
+    {% endif %}
+  {% endfor %}
+
   <!-- Boîte 1 : mesures environnementales -->
+  {% if ns.env %}
   <div class="box">
     <ul>
-      {% for key, val in data.items() %}
-        {% set k = key|lower %}
-        {% set is_air_quality = (
-             'co2' in k
-          or 'tvoc' in k
-          or 'voc' in k
-          or 'aqi' in k
-          or 'pm' in k
-          or 'hcho' in k
-          or 'no2' in k
-          or 'o3'  in k
-          or 'so2' in k
-          or (k == 'co')
-        ) %}
-        {% if not is_air_quality %}
-          <li>
-            <span class="sensor-name">{{ key }}:</span>
-            <span class="{% if 'DANGER' in val %}danger{% endif %}">{{ val | replace(' DANGER', '') | trim }}</span>
-          </li>
-        {% endif %}
+      {% for key, val in ns.env %}
+        <li>
+          <span class="sensor-name">{{ key }}:</span>
+          <span class="{% if 'DANGER' in val %}danger{% endif %}">{{ val | replace(' DANGER', '') | trim }}</span>
+        </li>
       {% endfor %}
     </ul>
   </div>
+  {% endif %}
 
   <!-- Boîte 2 : mesures qualité de l'air -->
+  {% if ns.air %}
   <div class="box">
     <ul>
-      {% for key, val in data.items() %}
-        {% set k = key|lower %}
-        {% if
-             'co2' in k
-          or 'tvoc' in k
-          or 'voc' in k
-          or 'aqi' in k
-          or 'pm' in k
-          or 'hcho' in k
-          or 'no2' in k
-          or 'o3'  in k
-          or 'so2' in k
-          or (k == 'co')
-        %}
-          <li>
-            <span class="sensor-name">{{ key }}:</span>
-            <span class="{% if 'DANGER' in val %}danger{% endif %}">{{ val | replace(' DANGER', '') | trim }}</span>
-          </li>
-        {% endif %}
+      {% for key, val in ns.air %}
+        <li>
+          <span class="sensor-name">{{ key }}:</span>
+          <span class="{% if 'DANGER' in val %}danger{% endif %}">{{ val | replace(' DANGER', '') | trim }}</span>
+        </li>
       {% endfor %}
     </ul>
   </div>
+  {% endif %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Only include sensor values that are actually read in the background thread.
- Remove fallback particulate data and clear previous readings on each update.
- Render web UI sections conditionally so categories appear only when data is available.

## Testing
- `python -m py_compile Rpi5/WebInterface.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdefc0334883268a962c21547d745f